### PR TITLE
Display notification instead of opening new tab when extension is updated

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -2,8 +2,20 @@ chrome.runtime.onInstalled.addListener(function (details) {
     var manifest = chrome.runtime.getManifest();
     var version = (manifest.version);
     if(details.reason == "update") {
-        var newURL = "https://github.com/wltrsjames/Ultrawide-Video";
-        chrome.tabs.create({ url: newURL });
+        chrome.notifications.create(null, {
+            type: "basic",
+            iconUrl: "images/icon.png",
+            title: "Ultrawide Video updated",
+            message: "Update log: Ultrawide Video is back! As of version "+version+" HBO GO has been added as a supported media player.",
+        }, function(updateNotificationId) {
+            chrome.notifications.onClicked.addListener(function(notificationId) {
+                if (notificationId === updateNotificationId) {
+                    var newURL = "https://github.com/wltrsjames/Ultrawide-Video";
+                    chrome.tabs.create({ url: newURL });
+                    chrome.notifications.clear(updateNotificationId);
+                }
+            });
+        });
     }
     chrome.storage.local.set({"extensionIsEnabled":false},function (){
         //console.log("Storage Succesful");

--- a/manifest.json
+++ b/manifest.json
@@ -8,7 +8,8 @@
     },
     "permissions": [
         "tabs",
-        "storage"
+        "storage",
+        "notifications"
     ],
     "content_scripts": [
         {


### PR DESCRIPTION
I thought it was really annoying that the extension opens a new tab when it's updated, so I spent a couple minutes adding code to display a notification instead. 