### PR TITLE
Detect fullscreen state when using F11

### DIFF
--- a/js/UltraWide.js
+++ b/js/UltraWide.js
@@ -28,7 +28,12 @@ UltraWide.prototype.update = function() {
 	+".extraClassCrop { -webkit-transform:scale("+this.scale+")!important; }";
 	
 	//Update classes:
-	const fullscreen = document.webkitIsFullScreen;
+	var fullscreen = document.webkitIsFullScreen;
+	//Detect F11 fullscreen mode
+	if (screen.height === window.innerHeight && screen.width === window.innerWidth) {
+		fullscreen = true;
+	}
+
 	console.log("[UltraWide] Page Update", this.mode, this.scale, fullscreen);
 	switch(this.mode) {
 	case 0: //Disabled


### PR DESCRIPTION
When using YouTube TV (youtube.com/tv). There is no fullscreen button.
Instead, F11 is used for fullscreen viewing.

To detect this, we must check the screen width/height with the window
inner width/height.